### PR TITLE
Fix Typographical Errors in Comments and Documentation

### DIFF
--- a/Aztec-Passport/apps/www/src/lib/helpers.ts
+++ b/Aztec-Passport/apps/www/src/lib/helpers.ts
@@ -166,7 +166,7 @@ export const getEmail = async (accessToken: string, service: Service) => {
 };
 
 export const extractXUsername = (email: string): string => {
-  // email contains the follwing
+  // email contains the following
   // If you requested a password reset for @dummy_testing_, use the confirmation code below to complete the process. If you didn't make this request, ignore this email.
   // extract username which is after If you requested a password reset for and till ,
 

--- a/OfflineMembership/README.md
+++ b/OfflineMembership/README.md
@@ -27,7 +27,7 @@ Those who'd like to use it [were invited](https://github.com/skaunov/note_histor
 
 ## Lessons Learned (For Submission)
 
-It's a great example of working with the archive tree and its nodes. An intresting blend of a standalone circuit and the blockchain data. 
+It's a great example of working with the archive tree and its nodes. An interesting blend of a standalone circuit and the blockchain data. 
 
 In a way this highlights DA and publication since getting the notes is on the one hand a subtle process easy to miss, on the other hand with enough industry it can be extracted from own PXE. And things gets even more interesting when user wants to hop between devices.
 


### PR DESCRIPTION
# Fix Typographical Errors in Comments and Documentation

## Description

This pull request addresses two typographical errors in the project codebase and documentation. These changes improve readability and maintain consistency throughout the project.

### Summary of Changes

#### **File:** `Aztec-Passport/apps/www/src/lib/helpers.ts`
- **Typo:** "follwing" corrected to "following."
  - **Original:** `email contains the follwing`
  - **Corrected:** `email contains the following`

#### **File:** `OfflineMembership/README.md`
- **Typo:** "intresting" corrected to "interesting."
  - **Original:** `An intresting blend of a standalone circuit and the blockchain data.`
  - **Corrected:** `An interesting blend of a standalone circuit and the blockchain data.`

### Why These Fixes Are Important

- Enhances clarity for developers working with the code and documentation.
- Eliminates potential confusion caused by misspelled words.
- Reflects a polished and professional project image.

---

## Checklist

- [x] Corrected typographical errors in both files.
- [x] Verified that no additional or unintended changes were made.
- [x] Followed [GitHub Community Guidelines](https://docs.github.com/en/get-started/quickstart/contributing-to-projects).

---

### Notes for Reviewers

These changes are minor and focus solely on improving text accuracy. Please review and merge at your earliest convenience. If any adjustments are needed, feel free to provide feedback.

Thank you!
