### PR TITLE
chore: Fix typos in code comments and documentation

### DIFF
--- a/Aztec-Passport/apps/www/src/lib/helpers.ts
+++ b/Aztec-Passport/apps/www/src/lib/helpers.ts
@@ -166,7 +166,7 @@ export const getEmail = async (accessToken: string, service: Service) => {
 };
 
 export const extractXUsername = (email: string): string => {
-  // email contains the follwing
+  // email contains the following
   // If you requested a password reset for @dummy_testing_, use the confirmation code below to complete the process. If you didn't make this request, ignore this email.
   // extract username which is after If you requested a password reset for and till ,
 

--- a/OfflineMembership/README.md
+++ b/OfflineMembership/README.md
@@ -27,7 +27,7 @@ Those who'd like to use it [were invited](https://github.com/skaunov/note_histor
 
 ## Lessons Learned (For Submission)
 
-It's a great example of working with the archive tree and its nodes. An intresting blend of a standalone circuit and the blockchain data. 
+It's a great example of working with the archive tree and its nodes. An interesting blend of a standalone circuit and the blockchain data. 
 
 In a way this highlights DA and publication since getting the notes is on the one hand a subtle process easy to miss, on the other hand with enough industry it can be extracted from own PXE. And things gets even more interesting when user wants to hop between devices.
 


### PR DESCRIPTION
A couple of typos in the codebase and documentation:  

- In `Aztec-Passport/apps/www/src/lib/helpers.ts`, corrected "follwing" to "following" in a comment.  
- In `OfflineMembership/README.md`, fixed "intresting" to "interesting" in the project description.  

These changes improve readability and accuracy.